### PR TITLE
feat: tambah auto-detect key/IV untuk ZTE F670 (payload type 5)

### DIFF
--- a/zcu/known_keys.py
+++ b/zcu/known_keys.py
@@ -123,6 +123,21 @@ def run_all_keygens(params):
 
     return outArr
 
+# Kunci hardcoded untuk payload type 5 (key/IV per tanda tangan model)
+KNOWN_TYPE5_KEYS = {
+    "F670": ("L04&Product@5A238dc79b15726d5c06", "ZTE%FN$GponNJ025678b02a85c63c706"),
+}
+
+
+def find_type5_key(signature):
+    """Cari key dan IV untuk payload type 5 berdasarkan tanda tangan model."""
+    sig = signature.strip()
+    for model, (key, iv) in KNOWN_TYPE5_KEYS.items():
+        if sig.upper().startswith(model.upper()):
+            return (key, iv)
+    return None
+
+
 def run_any_keygen(params, wanted):
     keygened = run_keygen(params)
     if keygened is not None:


### PR DESCRIPTION
Saat ini config.bin dari ZTE F670 (payload type 5) tidak bisa didecode secara otomatis — user harus memasukkan `--key-prefix` dan `--iv-prefix` secara manual, sementara keynya sendiri tidak terdokumentasi. Key ini didapat dari reverse engineering `libhardcode.so` firmware F670, sama seperti yang dilakukan di [mkst/zte-config-utility PR#118](https://github.com/mkst/zte-config-utility/pull/118).

## Perubahan

Tambah `KNOWN_TYPE5_KEYS` dan `find_type5_key()` di `zcu/known_keys.py` untuk menyimpan key/IV hardcoded per model pada payload type 5.

Untuk melengkapi auto-detect, disarankan patch berikut di `decoder.py` bagian payload type 5:

```python
elif payload_type == 5:
    key_p = args.key_prefix
    iv_p  = args.iv_prefix
    if not key_p:
        auto = zcu.known_keys.find_type5_key(params.signature)
        if auto:
            key_p, iv_p = auto
            print(f"Auto-detect key untuk: {params.signature}")
    if not key_p or not iv_p:
        error("Gunakan --key-prefix dan --iv-prefix, atau tambahkan model ke KNOWN_TYPE5_KEYS.")
        return 1
    ...
```

## Test

- Device: ZTE F670, firmware V6.0.10P3N32
- PON Serial: ZTEGD4CA5762
- Hasil: decode berhasil tanpa parameter manual